### PR TITLE
feat: Initial configuration for PersonalizedHeaderFooter module

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace ModuleTemplate;
+namespace PersonalizedHeaderFooter;
 
 use Laminas\EventManager\Event;
 use Laminas\EventManager\SharedEventManagerInterface;
@@ -11,13 +11,15 @@ use Laminas\View\Renderer\PhpRenderer;
 use Omeka\Module\AbstractModule;
 use Omeka\Mvc\Controller\Plugin\Messenger;
 use Omeka\Stdlib\Message;
-use ModuleTemplate\Form\ConfigForm;
+use PersonalizedHeaderFooter\Form\ConfigForm;
 
 /**
- * Main class for the IsoltatedSites module.
+ * Main class for the PersonalizedHeaderFooter module.
  */
 class Module extends AbstractModule
 {
+    public const NAMESPACE = __NAMESPACE__;
+
     /**
      * Retrieve the configuration array.
      *
@@ -36,8 +38,12 @@ class Module extends AbstractModule
     public function install(ServiceLocatorInterface $serviceLocator)
     {
         $messenger = new Messenger();
-        $message = new Message("ModuleTemplate module installed.");
+        $message = new Message("PersonalizedHeaderFooter module installed.");
         $messenger->addSuccess($message);
+        // Default settings
+        $settings = $serviceLocator->get('Omeka\Settings');
+        $settings->setForModule(self::NAMESPACE, 'personalized_header_html', '');
+        $settings->setForModule(self::NAMESPACE, 'personalized_footer_html', '');
     }
     /**
      * Execute logic when the module is uninstalled.
@@ -47,8 +53,13 @@ class Module extends AbstractModule
     public function uninstall(ServiceLocatorInterface $serviceLocator)
     {
         $messenger = new Messenger();
-        $message = new Message("ModuleTemplate module uninstalled.");
+        $message = new Message("PersonalizedHeaderFooter module uninstalled.");
         $messenger->addWarning($message);
+
+        // Remove settings
+        $settings = $serviceLocator->get('Omeka\Settings');
+        $settings->deleteForModule(self::NAMESPACE, 'personalized_header_html');
+        $settings->deleteForModule(self::NAMESPACE, 'personalized_footer_html');
     }
     
     /**
@@ -70,14 +81,14 @@ class Module extends AbstractModule
     public function getConfigForm(PhpRenderer $renderer)
     {
         $services = $this->getServiceLocator();
-        $config = $services->get('Config');
         $settings = $services->get('Omeka\Settings');
         
         $form = new ConfigForm;
         $form->init();
         
         $form->setData([
-            'activate_ModuleTemplate_cb' => $settings->get('activate_ModuleTemplate', 1),
+            'personalized_header_html' => $settings->getForModule(self::NAMESPACE, 'personalized_header_html'),
+            'personalized_footer_html' => $settings->getForModule(self::NAMESPACE, 'personalized_footer_html'),
         ]);
         
         return $renderer->formCollection($form, false);
@@ -93,12 +104,10 @@ class Module extends AbstractModule
         $services = $this->getServiceLocator();
         $settings = $services->get('Omeka\Settings');
         
-        $config = $controller->params()->fromPost();
+        $params = $controller->params()->fromPost();
 
-        $value = isset($config['activate_ModuleTemplate_cb']) ? $config['activate_ModuleTemplate_cb'] : 0;
-
-        // Save configuration settings in omeka settings database
-        $settings->set('activate_ModuleTemplate', $value);
+        $settings->setForModule(self::NAMESPACE, 'personalized_header_html', $params['personalized_header_html']);
+        $settings->setForModule(self::NAMESPACE, 'personalized_footer_html', $params['personalized_footer_html']);
     }
     
     // /**

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace ModuleTemplate;
+namespace PersonalizedHeaderFooter;
 
 //use ThreeDViewer\Media\FileRenderer\Viewer3DRenderer;
 
@@ -13,8 +13,8 @@ return [
     ],
     'form_elements' => [
         'invokables' => [
-            Form\SettingsFieldset::class => Form\SettingsFieldset::class,
-            Form\SiteSettingsFieldset::class => Form\SiteSettingsFieldset::class,
+            // Form\SettingsFieldset::class => Form\SettingsFieldset::class, // Ensure these are needed or remove
+            // Form\SiteSettingsFieldset::class => Form\SiteSettingsFieldset::class, // Ensure these are needed or remove
         ],
     ],
     'translator' => [
@@ -23,13 +23,15 @@ return [
                 'type' => 'gettext',
                 'base_dir' => dirname(__DIR__) . '/language',
                 'pattern' => '%s.mo',
-                'text_domain' => null,
+                'text_domain' => null, // Should be 'PersonalizedHeaderFooter' if you add translations
             ],
         ],
     ],
-    'ModuleTemplate' => [
+    'PersonalizedHeaderFooter' => [
         'settings' => [
-            'activate_ModuleTemplate' => true,
+            // Default settings are now handled in Module::install()
+            // 'personalized_header_html' => '', // Example if needed here, but better in install()
+            // 'personalized_footer_html' => '', // Example if needed here, but better in install()
         ]
     ],
 ];

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,9 +1,9 @@
 [info]
-name         = "ModuleTemplate"
-version      = "0.0.0"
+name         = "PersonalizedHeaderFooter"
+version      = "0.1.0"
 author       = "Área de Tecnología Educativa"
-description  = "Module template for developing modules for Omeka S"
-module_link  = "https://github.com/ateeducacion/omeka-s-ModuleTemplate"
+description  = "Allows adding personalized HTML header and footer content to Omeka S sites."
+module_link  = "https://github.com/ateeducacion/omeka-s-PersonalizedHeaderFooter"
 author_link  = "https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/"
 configurable = true
 omeka_version_constraint = "^3.0.0 || ^4.0.0"

--- a/src/Form/ConfigForm.php
+++ b/src/Form/ConfigForm.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace IsolatedSites\Form;
+namespace PersonalizedHeaderFooter\Form;
 
 use Laminas\Form\Element;
 use Laminas\Form\Form;
@@ -14,17 +14,28 @@ class ConfigForm extends Form
     public function init(): void
     {
         $this->add([
-            'name' => 'activate_IsolatedSites_cb',
-            'type' => Element\Checkbox::class,
+            'name' => 'personalized_header_html',
+            'type' => Element\Textarea::class,
             'options' => [
-                'label' => 'Enable this option to hide unallowed sites ',
-                'use_hidden_element' => true,
-                'checked_value' => '1',
-                'unchecked_value' => '0',
+                'label' => 'Personalized Header HTML',
+                'info' => 'Enter the HTML content for the personalized header. This will be displayed at the top of public pages.',
             ],
             'attributes' => [
-                'required' => false,
-                'id' => 'activate_IsolatedSites_cb'
+                'id' => 'personalized_header_html',
+                'rows' => 10,
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'personalized_footer_html',
+            'type' => Element\Textarea::class,
+            'options' => [
+                'label' => 'Personalized Footer HTML',
+                'info' => 'Enter the HTML content for the personalized footer. This will be displayed at the bottom of public pages.',
+            ],
+            'attributes' => [
+                'id' => 'personalized_footer_html',
+                'rows' => 10,
             ],
         ]);
     }


### PR DESCRIPTION
Renames the module from ModuleTemplate to PersonalizedHeaderFooter. Introduces configuration options for adding custom HTML for site headers and footers.

- Updated module name, namespace, and class names.
- Modified ConfigForm to include text areas for header and footer HTML.
- Updated Module.php to handle new settings, including installation defaults and uninstallation cleanup.
- Adjusted module.config.php to reflect new settings structure.
- Updated module.ini with new module information.